### PR TITLE
Apply events first, to allow "create" to work

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -112,7 +112,7 @@ class Widget extends \yii\base\Widget
             $id = $this->options['id'];
         }
         JuiAsset::register($this->getView());
-        $this->registerClientOptions($name, $id);
         $this->registerClientEvents($name, $id);
+        $this->registerClientOptions($name, $id);
     }
 }


### PR DESCRIPTION
Issue found using "sliderInput" where create does not work as the object is already intialized
